### PR TITLE
Fix Sitemap error message

### DIFF
--- a/core/components/seosuite/src/Snippets/Sitemap.php
+++ b/core/components/seosuite/src/Snippets/Sitemap.php
@@ -343,7 +343,7 @@ class Sitemap extends Base
                     SeoSuiteResource::class,
                     'SeoSuiteResource',
                     'SeoSuiteResource.',
-                    array_keys($this->modx->getFields('SeoSuiteResource'))
+                    array_keys($this->modx->getFields(SeoSuiteResource::class))
                 )
             ]
         );


### PR DESCRIPTION
Calling the snippet `[[!SeoSuiteSitemap]]` creates an error message: 

```
Could not load class: SeoSuiteResource from mysql.seosuiteresource
```

---

Related forum topic:
https://community.modx.com/t/seosuite-and-sitemap-on-modx-3/7278